### PR TITLE
Change the default engine to WebGL

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,7 +138,7 @@
                             <div id="renderer-select" class="tab">
                                 <select id="renderer-dropdown">
                                     <option value="sw">Software</option>
-                                    <option value="gl">WebGL</option>
+                                    <option value="gl" selected>WebGL</option>
                                     <option value="wg">WebGPU</option>
                                 </select>
                                 <svg class="arrow-icon" viewBox="0 0 24 24">

--- a/main.js
+++ b/main.js
@@ -26,7 +26,7 @@ var filetype;
 var filename;
 var filedata;
 var size = 800;
-var renderer = 'sw';
+var renderer = 'gl';
 
 //console output
 const ConsoleLogTypes = { None : '', Inner : 'console-type-inner', Error : 'console-type-error', Warning : 'console-type-warning' };


### PR DESCRIPTION
As webgl is fully compatible and stable, changing default engine of the viewer to WebGL.

issue: #135