### PR TITLE
Display Canvas Size with actual resolution

### DIFF
--- a/main.js
+++ b/main.js
@@ -141,6 +141,7 @@ function initialize() {
 
     document.getElementById("zoom-slider").addEventListener("input", onZoomSlider, false);
     document.getElementById("zoom-value").addEventListener("keydown", onZoomValue, false);
+    document.getElementById("zoom-value").textContent = size + " x " + size;
 
     document.getElementById("progress-slider").addEventListener("input", onProgressSlider, false);
     document.getElementById("progress-play").addEventListener("click", onProgressPlay, false);
@@ -302,6 +303,7 @@ function loadData(data, fileExtension) {
         enableZoomContainer();
         enableProgressContainer();
         initQualityValue();
+        requestAnimationFrame(() => refreshZoomValue());
     }, 100);
 }
 
@@ -493,10 +495,10 @@ function onConsoleWindow(event) {
 
 function onZoomSlider(event) {
     var value = event.target.value;
-    size = Math.floor(512 * (value / 100 + 0.25));
+    size = Math.floor(640 * (value / 100 + 0.25));
 
     resize(size, size);
-    refreshZoomValue();
+    requestAnimationFrame(() => refreshZoomValue());
 }
 
 function onZoomValue(event) {
@@ -505,7 +507,7 @@ function onZoomValue(event) {
         var matched = value.match(/^(\d{1,5})\s*x\s*(\d{1,5})$/);
         if (matched) {
             resize(matched[1], matched[2]);
-            refreshZoomValue();
+            requestAnimationFrame(() => refreshZoomValue());
         } else {
             event.srcElement.classList.add("incorrect");
         }
@@ -670,7 +672,12 @@ function refreshProgressValue() {
 
 function refreshZoomValue() {
     var value = document.getElementById("zoom-value");
-    value.innerHTML = player.offsetWidth + " x " + player.offsetHeight;
+
+    var canvas = player.querySelector('canvas');
+    const width = Math.round(canvas.width);
+    const height = Math.round(canvas.height);
+    value.innerHTML = width + " x " + height;
+
     value.classList.remove("incorrect");
 }
 

--- a/style.css
+++ b/style.css
@@ -823,7 +823,7 @@ lottie-player {
     overflow: hidden;
     display: block;
     z-index: 100;
-    border: 1px solid rgba(136, 136, 136, 0.3);
+    outline: 1px solid rgba(136, 136, 136, 0.3);
 }
 
 #renderer-select {


### PR DESCRIPTION
This PR updates the viewer to use the display content size by applying zoom based on the actual canvas size, related to enabling DPR default in thorvg.web. 

<img width="2060" height="1658" alt="CleanShot 2025-12-19 at 20 43 13@2x" src="https://github.com/user-attachments/assets/30dfcfc3-d256-447b-b889-54a914536997" />

Note: the default display zoom value will be different based on each user-end DPR value. (Previously, always 800 x 800)

issue: https://github.com/thorvg/thorvg.viewer/issues/107