### PR TITLE
 fix SVG not rendering on HW backends until resize

### DIFF
--- a/main.js
+++ b/main.js
@@ -293,10 +293,10 @@ function loadData(data, fileExtension) {
 
     initPlayer();
 
-    // FIXME: delay should be removed
-    setTimeout(async () => {
+    requestAnimationFrame(async () => {
+        player.style.width = `${size}px`;
+        player.style.height = `${size}px`;
         await player.load(data, fileExtension);
-        resize(size, size);
         createTabs();
         showImageCanvas();
         createFilesListTab();
@@ -304,7 +304,7 @@ function loadData(data, fileExtension) {
         enableProgressContainer();
         initQualityValue();
         requestAnimationFrame(() => refreshZoomValue());
-    }, 100);
+    });
 }
 
 function loadFile(file) {


### PR DESCRIPTION
Calling resize() after player.load() cleared the WebGL buffer and TVG.update() returned false (no size change), skipping the re-render for static content. Set player dimensions before load instead, so the internal _render() draws at the correct size.

issue: https://github.com/thorvg/thorvg.web/issues/251